### PR TITLE
feat/migrate-from-lucia-to-oslo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,9 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@lucia-auth/adapter-prisma": "^4.0.1",
         "@node-rs/argon2": "^2.0.0",
+        "@oslojs/crypto": "^1.0.1",
+        "@oslojs/encoding": "^1.1.0",
         "@prisma/client": "^5.22.0",
         "@radix-ui/react-alert-dialog": "^1.1.2",
         "@radix-ui/react-avatar": "^1.1.1",
@@ -27,7 +28,6 @@
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
         "fastest-levenshtein": "^1.0.16",
-        "lucia": "^3.2.2",
         "lucide-react": "^0.454.0",
         "next": "15.0.2",
         "next-themes": "^0.4.3",
@@ -1020,15 +1020,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@lucia-auth/adapter-prisma": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@lucia-auth/adapter-prisma/-/adapter-prisma-4.0.1.tgz",
-      "integrity": "sha512-3SztRhj1RAHbbhI/0aB7YC5zl6Z6aktPhkWpn2CHhiB03B9x/+A+M6pqJuAt1usU8PzkjVilgRPhrPymMar66A==",
-      "peerDependencies": {
-        "@prisma/client": "^4.2.0 || ^5.0.0",
-        "lucia": "3.x"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -5649,15 +5640,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
-    },
-    "node_modules/lucia": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/lucia/-/lucia-3.2.2.tgz",
-      "integrity": "sha512-P1FlFBGCMPMXu+EGdVD9W4Mjm0DqsusmKgO7Xc33mI5X1bklmsQb0hfzPhXomQr9waWIBDsiOjvr1e6BTaUqpA==",
-      "dependencies": {
-        "@oslojs/crypto": "^1.0.1",
-        "@oslojs/encoding": "^1.1.0"
-      }
     },
     "node_modules/lucide-react": {
       "version": "0.454.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "prisma-seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
-    "@lucia-auth/adapter-prisma": "^4.0.1",
     "@node-rs/argon2": "^2.0.0",
+    "@oslojs/crypto": "^1.0.1",
+    "@oslojs/encoding": "^1.1.0",
     "@prisma/client": "^5.22.0",
     "@radix-ui/react-alert-dialog": "^1.1.2",
     "@radix-ui/react-avatar": "^1.1.1",
@@ -31,7 +32,6 @@
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
     "fastest-levenshtein": "^1.0.16",
-    "lucia": "^3.2.2",
     "lucide-react": "^0.454.0",
     "next": "15.0.2",
     "next-themes": "^0.4.3",

--- a/src/app/_navigation/account-dropdown.tsx
+++ b/src/app/_navigation/account-dropdown.tsx
@@ -1,4 +1,4 @@
-import { User as AuthUser } from "lucia";
+import { User } from "@prisma/client";
 import { LucideLock, LucideLogOut, LucideUser } from "lucide-react";
 import Link from "next/link";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -14,7 +14,7 @@ import { signOut } from "@/features/auth/actions/sign-out";
 import { accountPasswordPath, accountProfilePath } from "@/paths";
 
 type AccountDropdownProps = {
-  user: AuthUser;
+  user: User;
 };
 
 const AccountDropdown = ({ user }: AccountDropdownProps) => {

--- a/src/features/auth/actions/sign-in.ts
+++ b/src/features/auth/actions/sign-in.ts
@@ -1,7 +1,5 @@
 "use server";
 
-import { verify } from "@node-rs/argon2";
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { z } from "zod";
 import {
@@ -9,9 +7,12 @@ import {
   fromErrorToActionState,
   toActionState,
 } from "@/components/form/utils/to-action-state";
-import { lucia } from "@/lib/lucia";
+import { verifyPasswordHash } from "@/features/password/utils/hash-and-verify";
+import { createSession } from "@/lib/lucia";
 import { prisma } from "@/lib/prisma";
 import { ticketsPath } from "@/paths";
+import { generateRandomToken } from "@/utils/crypto";
+import { setSessionCookie } from "../utils/session-cookie";
 
 const signInSchema = z.object({
   email: z.string().min(1, { message: "Is required" }).max(191).email(),
@@ -32,20 +33,16 @@ export const signIn = async (_actionState: ActionState, formData: FormData) => {
       return toActionState("ERROR", "Incorrect email or password", formData);
     }
 
-    const validPassword = await verify(user.passwordHash, password);
+    const validPassword = await verifyPasswordHash(user.passwordHash, password);
 
     if (!validPassword) {
       return toActionState("ERROR", "Incorrect email or password", formData);
     }
 
-    const session = await lucia.createSession(user.id, {});
-    const sessionCookie = lucia.createSessionCookie(session.id);
+    const sessionToken = generateRandomToken();
+    const session = await createSession(sessionToken, user.id);
 
-    (await cookies()).set(
-      sessionCookie.name,
-      sessionCookie.value,
-      sessionCookie.attributes
-    );
+    await setSessionCookie(sessionToken, session.expiresAt);
   } catch (error) {
     return fromErrorToActionState(error, formData);
   }

--- a/src/features/auth/actions/sign-out.ts
+++ b/src/features/auth/actions/sign-out.ts
@@ -1,10 +1,10 @@
 "use server";
 
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { lucia } from "@/lib/lucia";
+import { invalidateSession } from "@/lib/lucia";
 import { signInPath } from "@/paths";
 import { getAuth } from "../queries/get-auth";
+import { deleteSessionCookie } from "../utils/session-cookie";
 
 export const signOut = async () => {
   const { session } = await getAuth();
@@ -13,15 +13,8 @@ export const signOut = async () => {
     redirect(signInPath());
   }
 
-  await lucia.invalidateSession(session.id);
-
-  const sessionCookie = lucia.createBlankSessionCookie();
-
-  (await cookies()).set(
-    sessionCookie.name,
-    sessionCookie.value,
-    sessionCookie.attributes
-  );
+  await invalidateSession(session.id);
+  await deleteSessionCookie();
 
   redirect(signInPath());
 };

--- a/src/features/auth/actions/sign-up.ts
+++ b/src/features/auth/actions/sign-up.ts
@@ -1,8 +1,6 @@
 "use server";
 
-import { hash } from "@node-rs/argon2";
 import { Prisma } from "@prisma/client";
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { z } from "zod";
 import {
@@ -10,9 +8,12 @@ import {
   fromErrorToActionState,
   toActionState,
 } from "@/components/form/utils/to-action-state";
-import { lucia } from "@/lib/lucia";
+import { hashPassword } from "@/features/password/utils/hash-and-verify";
+import { createSession } from "@/lib/lucia";
 import { prisma } from "@/lib/prisma";
 import { ticketsPath } from "@/paths";
+import { generateRandomToken } from "@/utils/crypto";
+import { setSessionCookie } from "../utils/session-cookie";
 
 const signUpSchema = z
   .object({
@@ -44,7 +45,7 @@ export const signUp = async (_actionState: ActionState, formData: FormData) => {
       Object.fromEntries(formData)
     );
 
-    const passwordHash = await hash(password);
+    const passwordHash = await hashPassword(password);
 
     const user = await prisma.user.create({
       data: {
@@ -54,14 +55,10 @@ export const signUp = async (_actionState: ActionState, formData: FormData) => {
       },
     });
 
-    const session = await lucia.createSession(user.id, {});
-    const sessionCookie = lucia.createSessionCookie(session.id);
+    const sessionToken = generateRandomToken();
+    const session = await createSession(sessionToken, user.id);
 
-    (await cookies()).set(
-      sessionCookie.name,
-      sessionCookie.value,
-      sessionCookie.attributes
-    );
+    await setSessionCookie(sessionToken, session.expiresAt);
   } catch (error) {
     if (
       error instanceof Prisma.PrismaClientKnownRequestError &&

--- a/src/features/auth/hooks/use-auth.ts
+++ b/src/features/auth/hooks/use-auth.ts
@@ -1,10 +1,10 @@
-import { User as AuthUser } from "lucia";
+import { User } from "@prisma/client";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import { getAuth } from "../queries/get-auth";
 
 const useAuth = () => {
-  const [user, setUser] = useState<AuthUser | null>(null);
+  const [user, setUser] = useState<User | null>(null);
   const [isFetched, setFetched] = useState(false);
 
   const pathname = usePathname();

--- a/src/features/auth/queries/get-auth.ts
+++ b/src/features/auth/queries/get-auth.ts
@@ -2,41 +2,19 @@
 
 import { cookies } from "next/headers";
 import { cache } from "react";
-import { lucia } from "@/lib/lucia";
+import { validateSession } from "@/lib/lucia";
+import { SESSION_COOKIE_NAME } from "../utils/session-cookie";
 
 export const getAuth = cache(async () => {
-  const sessionId =
-    (await cookies()).get(lucia.sessionCookieName)?.value ?? null;
+  const sessionToken =
+    (await cookies()).get(SESSION_COOKIE_NAME)?.value ?? null;
 
-  if (!sessionId) {
+  if (!sessionToken) {
     return {
       user: null,
       session: null,
     };
   }
 
-  const result = await lucia.validateSession(sessionId);
-
-  try {
-    if (result.session && result.session.fresh) {
-      const sessionCookie = lucia.createSessionCookie(result.session.id);
-      (await cookies()).set(
-        sessionCookie.name,
-        sessionCookie.value,
-        sessionCookie.attributes
-      );
-    }
-    if (!result.session) {
-      const sessionCookie = lucia.createBlankSessionCookie();
-      (await cookies()).set(
-        sessionCookie.name,
-        sessionCookie.value,
-        sessionCookie.attributes
-      );
-    }
-  } catch {
-    // do nothing if used in a RSC
-  }
-
-  return result;
+  return await validateSession(sessionToken);
 });

--- a/src/features/auth/utils/is-owner.ts
+++ b/src/features/auth/utils/is-owner.ts
@@ -1,11 +1,11 @@
-import { User as AuthUser } from "lucia";
+import { User } from "@prisma/client";
 
 type Entity = {
   userId: string | null;
 };
 
 export const isOwner = (
-  authUser: AuthUser | null | undefined,
+  authUser: User | null | undefined,
   entity: Entity | null | undefined
 ) => {
   if (!authUser || !entity) {

--- a/src/features/auth/utils/session-cookie.ts
+++ b/src/features/auth/utils/session-cookie.ts
@@ -1,0 +1,38 @@
+import { cookies } from "next/headers";
+
+export const SESSION_COOKIE_NAME = "session";
+
+export const setSessionCookie = async (
+  sessionToken: string,
+  expiresAt: Date
+) => {
+  const cookie = {
+    name: SESSION_COOKIE_NAME,
+    value: sessionToken,
+    attributes: {
+      httpOnly: true,
+      sameSite: "lax" as const,
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      expires: expiresAt,
+    },
+  };
+
+  (await cookies()).set(cookie.name, cookie.value, cookie.attributes);
+};
+
+export const deleteSessionCookie = async () => {
+  const cookie = {
+    name: SESSION_COOKIE_NAME,
+    value: "",
+    attributes: {
+      httpOnly: true,
+      sameSite: "lax" as const,
+      secure: process.env.NODE_ENV === "production",
+      path: "/",
+      maxAge: 0,
+    },
+  };
+
+  (await cookies()).set(cookie.name, cookie.value, cookie.attributes);
+};

--- a/src/features/password/utils/hash-and-verify.ts
+++ b/src/features/password/utils/hash-and-verify.ts
@@ -1,0 +1,17 @@
+import { hash, verify } from "@node-rs/argon2";
+
+export const hashPassword = async (password: string) => {
+  return await hash(password, {
+    memoryCost: 19456,
+    timeCost: 2,
+    outputLen: 32,
+    parallelism: 1,
+  });
+};
+
+export const verifyPasswordHash = async (
+  passwordHash: string,
+  password: string
+) => {
+  return await verify(passwordHash, password);
+};

--- a/src/lib/lucia.ts
+++ b/src/lib/lucia.ts
@@ -1,30 +1,77 @@
-import { PrismaAdapter } from "@lucia-auth/adapter-prisma";
-import { Lucia } from "lucia";
+import { hashToken } from "@/utils/crypto";
 import { prisma } from "./prisma";
 
-const adapter = new PrismaAdapter(prisma.session, prisma.user);
+const SESSION_REFRESH_INTERVAL_MS = 1000 * 60 * 60 * 24 * 15; // 15 days
+const SESSION_MAX_DURATION_MS = SESSION_REFRESH_INTERVAL_MS * 2; // 30 days
 
-export const lucia = new Lucia(adapter, {
-  sessionCookie: {
-    expires: false,
-    attributes: {
-      secure: process.env.NODE_ENV === "production",
+export const createSession = async (sessionToken: string, userId: string) => {
+  const sessionId = hashToken(sessionToken);
+
+  const session = {
+    id: sessionId,
+    userId,
+    expiresAt: new Date(Date.now() + SESSION_MAX_DURATION_MS),
+  };
+
+  await prisma.session.create({
+    data: session,
+  });
+
+  return session;
+};
+
+export const validateSession = async (sessionToken: string) => {
+  const sessionId = hashToken(sessionToken);
+
+  const result = await prisma.session.findUnique({
+    where: {
+      id: sessionId,
     },
-  },
-  getUserAttributes: (attributes) => ({
-    username: attributes.username,
-    email: attributes.email,
-  }),
-});
+    include: {
+      user: true,
+    },
+  });
 
-declare module "lucia" {
-  interface Register {
-    Lucia: typeof lucia;
-    DatabaseUserAttributes: DatabaseUserAttributes;
+  // if there is no session, return null
+  if (!result) {
+    return { session: null, user: null };
   }
-}
 
-interface DatabaseUserAttributes {
-  username: string;
-  email: string;
-}
+  const { user, ...session } = result;
+
+  // if the session is expired, delete it
+  if (Date.now() >= session.expiresAt.getTime()) {
+    // or your ORM of choice
+    await prisma.session.delete({
+      where: {
+        id: sessionId,
+      },
+    });
+
+    return { session: null, user: null };
+  }
+
+  // if 15 days are left until the session expires, refresh the session
+  if (Date.now() >= session.expiresAt.getTime() - SESSION_REFRESH_INTERVAL_MS) {
+    session.expiresAt = new Date(Date.now() + SESSION_MAX_DURATION_MS);
+
+    await prisma.session.update({
+      where: {
+        id: sessionId,
+      },
+      data: {
+        expiresAt: session.expiresAt,
+      },
+    });
+  }
+
+  return { session, user };
+};
+
+export const invalidateSession = async (sessionId: string) => {
+  await prisma.session.delete({
+    where: {
+      id: sessionId,
+    },
+  });
+};

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,0 +1,15 @@
+import { sha256 } from "@oslojs/crypto/sha2";
+import {
+  encodeBase32LowerCaseNoPadding,
+  encodeHexLowerCase,
+} from "@oslojs/encoding";
+
+export const generateRandomToken = () => {
+  const bytes = new Uint8Array(20);
+  crypto.getRandomValues(bytes);
+  return encodeBase32LowerCaseNoPadding(bytes);
+};
+
+export const hashToken = (token: string) => {
+  return encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
+};


### PR DESCRIPTION
**Reason:** https://github.com/lucia-auth/lucia/discussions/1707

**TLDR:** Lucia, the authentication library that we are using, is deprecated (Q1/2025). However, the author of Lucia decided to make it a learning resource, because Lucia is just a thin wrapper around cryptographic libraries like Oslo. So we are following the migration path on their website and will also use Oslo instead of Lucia.


**What I/you had/have to do**: https://lucia-auth.com/sessions/migrate-lucia-v3 It should be pretty straightforward. Need more handholding? https://www.robinwieruch.de/how-to-roll-your-own-auth/

Why I still stick to Lucia and now Oslo? 

- still great primitives for rolling your own authentication
- being independent of paid third-parties
- learning about authentication
- being in control