### PR TITLE
Fix pagination when page is a negative number

### DIFF
--- a/src/features/ticket/search-params.ts
+++ b/src/features/ticket/search-params.ts
@@ -1,8 +1,23 @@
 import {
+  createParser,
   createSearchParamsCache,
   parseAsInteger,
   parseAsString,
 } from "nuqs/server";
+
+export const parseAsPositiveInteger = createParser({
+  parse: (v) => {
+    const int = parseInt(v);
+    if (Number.isNaN(int)) {
+      return null;
+    }
+    if (int < 0) {
+      return null;
+    }
+    return int;
+  },
+  serialize: (v) => Math.round(v).toFixed(),
+});
 
 export const searchParser = parseAsString.withDefault("").withOptions({
   shallow: false,
@@ -20,7 +35,7 @@ export const sortOptions = {
 };
 
 export const paginationParser = {
-  page: parseAsInteger.withDefault(0),
+  page: parseAsPositiveInteger.withDefault(0),
   size: parseAsInteger.withDefault(5),
 };
 


### PR DESCRIPTION
This PR fix issue when the page is a negative number which can't happen via UI but only if user change page by updating the URL manually.

There are surely different way to handle this but since we are using nuqs and there is not a parse as positive number I create a [custom parser](https://nuqs.47ng.com/docs/parsers/making-your-own). 