### PR TITLE
Use set query data instead of invalidate queries

### DIFF
--- a/src/features/comment/components/comments.tsx
+++ b/src/features/comment/components/comments.tsx
@@ -42,9 +42,61 @@ const Comments = ({ ticketId, paginatedComments }: CommentsProps) => {
 
   const queryClient = useQueryClient();
 
-  const handleDeleteComment = () => queryClient.invalidateQueries({ queryKey });
+  const handleDeleteComment = (id: string) => {
+    queryClient.setQueryData<{
+      pages: PaginatedData<CommentWithMetadata>[];
+      pageParams: string | undefined;
+    }>(queryKey, (old) => {
+      if (!old || !old.pages) {
+        return old;
+      }
 
-  const handleCreateComment = () => queryClient.invalidateQueries({ queryKey });
+      const filteredPages = old.pages.map((page) => ({
+        ...page,
+        list: page.list.filter((item) => item.id !== id), // Filter the list for each page
+      }));
+
+      const updatedPages = { ...old, pages: filteredPages };
+
+      console.log({ pagesAfter: updatedPages });
+
+      return updatedPages;
+    });
+
+    //queryClient.invalidateQueries({ queryKey });
+  };
+
+  const handleCreateComment = (comment: CommentWithMetadata | undefined) => {
+    queryClient.setQueryData<{
+      pages: PaginatedData<CommentWithMetadata>[];
+      pageParams: string | undefined;
+    }>(queryKey, (old) => {
+      if (!comment) {
+        return old;
+      }
+
+      if (!old) {
+        return old;
+      }
+
+      const updatedPages = {
+        ...old,
+        pages: [
+          {
+            ...old.pages[0], // Adding to the first page
+            list: [comment, ...(old.pages[0]?.list ?? [])], // Add comment to the list
+          },
+          ...old.pages.slice(1), // Preserve the rest of the pages
+        ],
+      };
+
+      console.log({ pagesAfter: updatedPages });
+
+      return updatedPages;
+    });
+
+    //queryClient.invalidateQueries({ queryKey });
+  };
 
   const { ref, inView } = useInView();
 


### PR DESCRIPTION
When using query invalidation to invalidate many pages, comments that are added or removed may not be reflected immediately in the UI. However, by manually setting the query data, the UI is updated immediately.

Video https://rwieruch.teachable.com/courses/the-road-to-next/lectures/53966009